### PR TITLE
Fix #19 console installation redirect error

### DIFF
--- a/src/AdWizard.php
+++ b/src/AdWizard.php
@@ -140,7 +140,7 @@ class AdWizard extends Plugin
             Plugins::class,
             Plugins::EVENT_AFTER_INSTALL_PLUGIN,
             static function (Event $event) {
-                if ('ad-wizard' == $event->plugin->handle) {
+                if ('ad-wizard' == $event->plugin->handle && !Craft::$app->getRequest()->getIsConsoleRequest()) {
                     $url = UrlHelper::cpUrl('ad-wizard/welcome');
                     Craft::$app->getResponse()->redirect($url)->send();
                 }


### PR DESCRIPTION
This small fix will prevent the redirect error when installing the plugin from CLI or project config.