### PR TITLE
Fix some untranslatable strings

### DIFF
--- a/src/AdWizard.php
+++ b/src/AdWizard.php
@@ -169,12 +169,12 @@ class AdWizard extends Plugin
 
         $groupsExist = $this->groups->getAllGroups();
 
-        $item['subnav']['stats'] = ['label' => 'Stats', 'url' => 'ad-wizard/stats'];
+        $item['subnav']['stats'] = ['label' => Craft::t('ad-wizard', 'Stats'), 'url' => 'ad-wizard/stats'];
         if ($groupsExist) {
-            $item['subnav']['ads'] = ['label' => 'Ads', 'url' => 'ad-wizard/ads'];
+            $item['subnav']['ads'] = ['label' => Craft::t('ad-wizard', 'Ads'), 'url' => 'ad-wizard/ads'];
         }
-        $item['subnav']['groups'] = ['label' => 'Groups', 'url' => 'ad-wizard/groups'];
-        $item['subnav']['fieldlayouts'] = ['label' => 'Field Layouts', 'url' => 'ad-wizard/fieldlayouts'];
+        $item['subnav']['groups'] = ['label' => Craft::t('ad-wizard', 'Groups'), 'url' => 'ad-wizard/groups'];
+        $item['subnav']['fieldlayouts'] = ['label' => Craft::t('ad-wizard', 'Field Layouts'), 'url' => 'ad-wizard/fieldlayouts'];
 
         return $item;
     }

--- a/src/templates/ads/_main.twig
+++ b/src/templates/ads/_main.twig
@@ -24,8 +24,8 @@
 
 <div class="field" id="adGraphic-field">
     <div class="heading">
-        <label for="adGraphic">Image</label>
-        <div class="instructions"><p>If no graphic is associated, the ad will not be displayed.</p></div>
+        <label for="adGraphic">{{ "Image"|t('app') }}</label>
+        <div class="instructions"><p>{{ "If no graphic is associated, the ad will not be displayed."|t('ad-wizard') }}</p></div>
     </div>
     <div class="input">
         {% if assetsSourceExists %}
@@ -41,13 +41,13 @@
                 },
                 sourceElementId: ad.id,
                 jsClass: 'Craft.AssetSelectInput',
-                selectionLabel: 'Select Ad Graphic',
+                selectionLabel: 'Select Ad Graphic'|t('ad-wizard'),
                 viewMode: 'large',
                 limit: 1,
                 modalStorageKey: 'adWizard.adGraphic',
             }) }}
         {% else %}
-            <p class="error">No asset volumes currently exist. <a href="{{ cpUrl('settings/assets') }}">Create one now...</a></p>
+            <p class="error">{{ "No asset volumes currently exist."|t('ad-wizard') }} <a href="{{ cpUrl('settings/assets') }}">{{ "Create one now..."|t('ad-wizard') }}</a></p>
         {% endif %}
     </div>
 </div>

--- a/src/templates/fieldlayouts/index.twig
+++ b/src/templates/fieldlayouts/index.twig
@@ -7,10 +7,10 @@
 
 {% set content %}
     <div id="nofieldlayouts"{% if fieldLayouts %} class="hidden"{% endif %}>
-        <h2>What is a Field Layout?</h2>
-        <p>As a custom element type, it's possible to assign custom fields to ads in each Group. Each field layout can be assigned to one or more Ad Group.</p>
+        <h2>{{ "What is a Field Layout?"|t('ad-wizard') }}</h2>
+        <p>{{ "As a custom element type, it's possible to assign custom fields to ads in each Group. Each field layout can be assigned to one or more Ad Group."|t('ad-wizard') }}</p>
         <hr/>
-        <p><strong>No field layouts exist yet.</strong> <a href="{{ cpUrl('ad-wizard/fieldlayouts/new') }}">Create one to get started...</a></p>
+        <p><strong>{{ "No field layouts exist yet."|t('ad-wizard') }}</strong> <a href="{{ cpUrl('ad-wizard/fieldlayouts/new') }}">{{ "Create one to get started..."|t('ad-wizard') }}</a></p>
     </div>
 
     {% if fieldLayouts %}

--- a/src/templates/groups/index.twig
+++ b/src/templates/groups/index.twig
@@ -7,10 +7,10 @@
 
 {% set content %}
     <div id="noadgroups"{% if groups %} class="hidden"{% endif %}>
-        <h2>What is a Group?</h2>
-        <p>When you create an Ad, you will place it into a specific Group. The relationship between an Ad &amp; Group is similar to the relationship between an Entry &amp; Section. It's not possible for an ad to exist in more than one group.</p>
+        <h2>{{ "What is a Group?"|t('ad-wizard') }}</h2>
+        <p>{{ "When you create an Ad, you will place it into a specific Group. The relationship between an Ad &amp; Group is similar to the relationship between an Entry &amp; Section. It's not possible for an ad to exist in more than one group."|t('ad-ziard') }}</p>
         <hr/>
-        <p><strong>No groups exist yet.</strong> <a href="{{ cpUrl('ad-wizard/groups/new') }}">Create one to get started...</a></p>
+        <p><strong>{{ "No groups exist yet."|t('ad-wizard') }}</strong> <a href="{{ cpUrl('ad-wizard/groups/new') }}">{{ "Create one to get started..."|t('ad-wizard') }}</a></p>
     </div>
 
     {% if groups %}

--- a/src/templates/stats/index.twig
+++ b/src/templates/stats/index.twig
@@ -34,19 +34,23 @@
             <tr>
                 <th>&nbsp;</th>
                 <th>&nbsp;</th>
-                <th colspan="2" class="aw-total col-divider">This Month ({{ month[thisMonth] }})</th>
-                <th colspan="2" class="aw-total col-divider">Last Month ({{ month[lastMonth] }})</th>
-                <th colspan="2" class="aw-total col-divider">Lifetime Total</th>
+                <th colspan="2" class="aw-total col-divider">{{ "This Month"|t('ad-wizard') }} ({{ '{m,date,LLLL}'|t('ad-wizard', params = {
+                    m:date().setDate(thisYear, thisMonth, 1).timestamp
+                }) }})</th>
+                <th colspan="2" class="aw-total col-divider">{{ "Last Month"|t('ad-wizard') }} ({{ '{m,date,LLLL}'|t('ad-wizard', params = {
+                    m:date().setDate(lastYear, lastMonth, 1).timestamp
+                }) }})</th>
+                <th colspan="2" class="aw-total col-divider">{{ "Lifetime Total"|t('ad-wizard') }}</th>
             </tr>
             <tr>
-                <th>Group</th>
-                <th>Ad</th>
-                <th class="aw-total aw-views col-divider">Views</th>
-                <th class="aw-total aw-clicks">Clicks</th>
-                <th class="aw-total aw-views col-divider">Views</th>
-                <th class="aw-total aw-clicks">Clicks</th>
-                <th class="aw-total aw-views col-divider">Views</th>
-                <th class="aw-total aw-clicks">Clicks</th>
+                <th>{{ "Group"|t('ad-wizard') }}</th>
+                <th>{{ "Ad"|t('ad-wizard') }}</th>
+                <th class="aw-total aw-views col-divider">{{ "Views"|t('ad-wizard') }}</th>
+                <th class="aw-total aw-clicks">{{ "Clicks"|t('ad-wizard') }}</th>
+                <th class="aw-total aw-views col-divider">{{ "Views"|t('ad-wizard') }}</th>
+                <th class="aw-total aw-clicks">{{ "Clicks"|t('ad-wizard') }}</th>
+                <th class="aw-total aw-views col-divider">{{ "Views"|t('ad-wizard') }}</th>
+                <th class="aw-total aw-clicks">{{ "Clicks"|t('ad-wizard') }}</th>
             </tr>
             </thead>
             <tbody>
@@ -66,13 +70,13 @@
                 {% set groupsExist = craft.adWizard.getAllGroups() %}
                 {% if groupsExist %}
                     {% set href  = cpUrl('ad-wizard/ads') %}
-                    {% set label = 'Create an ad...' %}
+                    {% set label = 'Create an ad...'|t('ad-wizard') %}
                 {% else %}
                     {% set href  = cpUrl('ad-wizard/groups') %}
-                    {% set label = 'Create an ad group...' %}
+                    {% set label = 'Create an ad group...'|t('ad-wizard') %}
                 {% endif %}
                 <tr>
-                    <td colspan="8" class="no-stats">You currently have no ads. <a href="{{ href }}">{{ label }}</a></td>
+                    <td colspan="8" class="no-stats">{{ 'You currently have no ads.'|t('ad-wizard') }} <a href="{{ href }}">{{ label }}</a></td>
                 </tr>
             {% endfor %}
             </tbody>


### PR DESCRIPTION
A client of mine needed the admin strings translated to French so I figured I would send back the work. It's just a bit of cleanup to pass some leftover strings to the twig filter + translatable dates.

Edit: P.S.: If you're interested in getting the French translation too, just let me know. I'd be more than happy to give it back too. 